### PR TITLE
Fix code scanning alert no. 22: Prototype-polluting assignment

### DIFF
--- a/server/Sockets/LobbyCreate.js
+++ b/server/Sockets/LobbyCreate.js
@@ -20,6 +20,9 @@ const LobbyCreate = (io, socket, users, rooms) => {
     users[socket.id].room.roomID = roomParam.room;
     users[socket.id].game.side = roomParam.side;
 
+    if (roomParam.room === '__proto__' || roomParam.room === 'constructor' || roomParam.room === 'prototype') {
+      return socket.emit('error', 'Invalid room name');
+    }
     rooms[roomParam.room] = Object.assign(Object.create(null), roomParam);
 
     rooms[roomParam.room].serverOSave = Object.assign(Object.create(null), {


### PR DESCRIPTION
Fixes [https://github.com/KANTNOLI/GameEngine-Checkers-From-KANTNOLI/security/code-scanning/22](https://github.com/KANTNOLI/GameEngine-Checkers-From-KANTNOLI/security/code-scanning/22)

To fix the problem, we need to ensure that the keys used in the `rooms` object cannot cause prototype pollution. We can achieve this by either using a `Map` object or by validating the keys to ensure they do not include dangerous properties like `__proto__`, `constructor`, or `prototype`.

The best way to fix this without changing existing functionality is to validate the keys in `roomParam` before using them. This approach is less intrusive and maintains the current data structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
